### PR TITLE
[FIX] GRPCStatus method

### DIFF
--- a/errors/validation_error.go
+++ b/errors/validation_error.go
@@ -27,7 +27,7 @@ func (e *ValidationError) Error() string {
 	return fmt.Sprintf("validation error(s): %v", violationMessages)
 }
 
-func (e *ValidationError) GRPCStatus() (*status.Status, error) {
+func (e *ValidationError) GRPCStatus() *status.Status {
 	st := status.New(codes.InvalidArgument, "invalid request")
 
 	violations := []*errdetails.BadRequest_FieldViolation{}
@@ -41,11 +41,12 @@ func (e *ValidationError) GRPCStatus() (*status.Status, error) {
 		)
 	}
 
-	return st.WithDetails(
-		&errdetails.BadRequest{
-			FieldViolations: violations,
-		},
-	)
+	detailed, err := st.WithDetails(&errdetails.BadRequest{FieldViolations: violations})
+	if err != nil {
+		return st
+	}
+
+	return detailed
 }
 
 func NewValidationError(violations []*FieldViolation) *ValidationError {

--- a/errors/validation_error_test.go
+++ b/errors/validation_error_test.go
@@ -32,9 +32,7 @@ func TestValidationError_GRPCStatus(t *testing.T) {
 	}
 	validationErr := NewValidationError(violations)
 
-	st, err := validationErr.GRPCStatus()
-
-	assert.NoError(t, err)
+	st := validationErr.GRPCStatus()
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Equal(t, "invalid request", st.Message())
 
@@ -79,9 +77,8 @@ func TestBuildViolations(t *testing.T) {
 func TestValidationError_GRPCStatus_NoViolations(t *testing.T) {
 	validationErr := NewValidationError(nil)
 
-	st, err := validationErr.GRPCStatus()
+	st := validationErr.GRPCStatus()
 
-	assert.NoError(t, err)
 	assert.Equal(t, codes.InvalidArgument, st.Code())
 	assert.Equal(t, "invalid request", st.Message())
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	go.uber.org/zap v1.27.0
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20240930140551-af27646dc61f
 	google.golang.org/grpc v1.67.1
-	google.golang.org/protobuf v1.34.2
 )
 
 require (
@@ -25,5 +24,6 @@ require (
 	golang.org/x/net v0.28.0 // indirect
 	golang.org/x/sys v0.24.0 // indirect
 	golang.org/x/text v0.17.0 // indirect
+	google.golang.org/protobuf v1.34.2 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )


### PR DESCRIPTION
- Refactor function signature to work with `fromError` and `Convert`